### PR TITLE
fix: suppress startup logging to resolve Amazon Q CLI loading issue

### DIFF
--- a/.vibe/development-plan-fix-startup-error-q-cli.md
+++ b/.vibe/development-plan-fix-startup-error-q-cli.md
@@ -1,0 +1,95 @@
+# Development Plan: responsible-vibe (fix-startup-error-q-cli branch)
+
+*Generated on 2025-09-17 by Vibe Feature MCP*
+*Workflow: [bugfix](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/bugfix)*
+
+## Goal
+Fix MCP server initialization issue where logger.info calls prevent Amazon Q CLI from loading the server
+
+## Reproduce
+### Tasks
+- [x] Identify the problematic logger.info call location
+- [x] Understand the MCP initialization sequence
+- [x] Reproduce the error scenario
+
+### Completed
+- [x] Created development plan file
+- [x] Found the issue: logger.info call on line 227 in src/index.ts happens BEFORE MCP server.connect()
+- [x] Confirmed the commented-out logger.info on line 244 was the fix attempt
+
+## Analyze
+### Phase Entrance Criteria:
+- [x] Bug has been reliably reproduced
+- [x] Error conditions and symptoms are documented
+- [x] Environment details are captured
+
+### Tasks
+- [x] Analyze the MCP server initialization sequence
+- [x] Identify all logging calls that happen before initialization completes
+- [x] Determine the safest fix approach (move logging vs suppress logging)
+- [x] Evaluate impact on debugging and troubleshooting
+
+### Completed
+- [x] Found problematic logger.info on line 227 in src/index.ts (before server.connect())
+- [x] Found additional logger.info on line 83 in src/server/index.ts (during server.initialize())
+- [x] Confirmed MCP protocol allows logging during initialization, but Amazon Q CLI expects initialize response first
+- [x] Identified three fix approaches: suppress, delay, or move logging
+
+## Fix
+### Phase Entrance Criteria:
+- [x] Root cause has been identified
+- [x] Fix approach has been determined
+- [x] Impact assessment is complete
+
+### Tasks
+- [x] Test the fix with Amazon Q CLI - FAILED: logging still happens too early
+
+### Completed
+- [x] Remove logger.info call from line 227 in src/index.ts (before server.connect())
+- [x] Remove logger.info call from line 83 in src/server/index.ts (during server.initialize())
+- [x] Add single logger.info call after server.connect() completes - REMOVED: still too early
+- [x] Completely suppress startup logging to ensure Amazon Q CLI compatibility
+
+### Completed
+*None yet*
+
+## Verify
+### Phase Entrance Criteria:
+- [ ] Fix has been implemented
+- [ ] Code changes are complete
+- [ ] Fix addresses the root cause
+
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Finalize
+### Phase Entrance Criteria:
+- [ ] Fix has been verified to work
+- [ ] No regressions have been introduced
+- [ ] All tests pass
+
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Key Decisions
+- **Root Cause Confirmed**: According to MCP specification, "The server SHOULD NOT send requests other than pings and logging before receiving the initialized notification."
+- **Error Pattern**: `expect initialized response, but received: Some(Notification(JsonRpcNotification { ... LoggingMessageNotification ...}))`
+- **Timing Issue**: The logger.info call on line 227 happens BEFORE the client sends the `initialized` notification, violating MCP protocol
+- **MCP Protocol Flow**: 1) Client sends `initialize` request → 2) Server responds → 3) Client sends `initialized` notification → 4) Normal operations begin
+- **Logging Allowed**: Servers CAN send logging notifications during initialization, but Amazon Q CLI implementation appears to expect the initialize response first
+- **Analysis Complete**: Two problematic logging calls identified:
+  - Line 227 src/index.ts: `logger.info('Starting Vibe Feature MCP Server'...)` - happens before server.connect()
+  - Line 83 src/server/index.ts: `logger.info('ResponsibleVibeMCPServer initialized successfully')` - happens during server.initialize()
+- **Fix Approach Revised**: Even after server.connect() completes, Amazon Q CLI still expects no logging until the full MCP handshake finishes. Completely suppressed startup logging to ensure compatibility.
+
+## Notes
+*Additional context and observations*
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,9 +121,9 @@ ENVIRONMENT VARIABLES:
   PROJECT_PATH    Set the project directory for custom workflow discovery
 
 DESCRIPTION:
-  A Model Context Protocol server that acts as an intelligent conversation 
-  state manager and development guide for LLMs. This server orchestrates 
-  feature development conversations by maintaining state, determining 
+  A Model Context Protocol server that acts as an intelligent conversation
+  state manager and development guide for LLMs. This server orchestrates
+  feature development conversations by maintaining state, determining
   development phases, and providing contextual instructions.
 
 WORKFLOW VISUALIZER:
@@ -133,17 +133,17 @@ WORKFLOW VISUALIZER:
 
 CONFIGURATION GENERATOR:
   Use --generate-config to create configuration files for AI coding agents:
-  
+
   Amazon Q CLI: --generate-config amazonq-cli  (generates .amazonq/cli-agents/vibe.json)
   Claude Code:  --generate-config claude       (generates CLAUDE.md, .mcp.json, settings.json)
   Gemini CLI:   --generate-config gemini       (generates settings.json, GEMINI.md)
-  
+
   Files are generated in the current directory with pre-configured settings
   for the responsible-vibe-mcp server and default tool permissions.
 
 MCP CLIENT CONFIGURATION:
   Add to your MCP client configuration:
-  
+
   Claude Desktop (.claude/config.json):
   {
     "mcpServers": {
@@ -153,12 +153,12 @@ MCP CLIENT CONFIGURATION:
       }
     }
   }
-  
+
   Amazon Q (.amazonq/mcp.json):
   {
     "mcpServers": {
       "responsible-vibe-mcp": {
-        "command": "npx", 
+        "command": "npx",
         "args": ["responsible-vibe-mcp"]
       }
     }
@@ -221,12 +221,6 @@ async function main() {
   try {
     const projectPath = process.env.PROJECT_PATH;
 
-    logger.info('Starting Vibe Feature MCP Server', {
-      projectPath: projectPath || 'default (process.cwd())',
-      nodeVersion: process.version,
-      platform: process.platform,
-    });
-
     // Create server instance with project path configuration
     const server = new ResponsibleVibeMCPServer({
       projectPath: projectPath,
@@ -241,7 +235,8 @@ async function main() {
     // Connect server to transport
     await server.getMcpServer().connect(transport);
 
-    logger.info('Vibe Feature MCP Server started successfully');
+    // Note: No logging here to ensure compatibility with Amazon Q CLI
+    // Amazon Q CLI expects no logging notifications before MCP initialization completes
 
     // Handle graceful shutdown
     process.on('SIGINT', async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -79,8 +79,6 @@ export class ResponsibleVibeMCPServer {
         responseRenderer,
         this.components.context
       );
-
-      logger.info('ResponsibleVibeMCPServer initialized successfully');
     } catch (error) {
       logger.error(
         'Failed to initialize ResponsibleVibeMCPServer',


### PR DESCRIPTION
- Remove logger.info calls during MCP server initialization
- Amazon Q CLI expects no logging notifications before MCP handshake completes
- Ensures compatibility with strict MCP protocol interpretation

Fixes: MCP server loading failure with error -32002