### PR TITLE
feat: add no_idea tool to prevent hallucinations

### DIFF
--- a/.vibe/development-plan-no-idea-tool.md
+++ b/.vibe/development-plan-no-idea-tool.md
@@ -1,0 +1,166 @@
+# Development Plan: responsible-vibe (no-idea-tool branch)
+
+*Generated on 2025-09-21 by Vibe Feature MCP*
+*Workflow: [epcc](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/epcc)*
+
+## Goal
+Add an anti-hallucination tool to the responsible-vibe-mcp server that LLMs can call when they have no knowledge about something, preventing hallucinated responses and providing honest acknowledgment of knowledge gaps.
+
+## Explore
+### Tasks
+- [x] ~~Understand existing MCP tool architecture and patterns~~
+- [x] ~~Define tool interface and behavior specifications~~
+- [x] ~~Identify integration points with existing MCP tools~~
+- [x] ~~Document requirements for the anti-hallucination tool~~
+
+### Completed
+- [x] Created development plan file
+- [x] Explored codebase structure and identified key directories
+- [x] Analyzed existing tool handler patterns (BaseToolHandler, tool registration)
+- [x] Understood MCP server configuration and tool registration process
+- [x] Identified integration points with existing MCP tools
+- [x] Defined tool interface with NoIdeaArgs and NoIdeaResponse types
+- [x] Specified behavior for general knowledge gaps and document creation scenarios
+- [x] Documented complete requirements for the anti-hallucination tool
+
+## Plan
+
+### Phase Entrance Criteria:
+- [x] The requirements have been thoroughly defined
+- [x] Existing codebase structure and patterns are understood
+- [x] Tool interface and behavior specifications are clear
+- [x] Integration points with existing MCP tools are identified
+
+### Tasks
+- [x] ~~Create detailed implementation strategy~~ → SIMPLIFIED
+- [x] ~~Define file structure and naming conventions~~
+- [x] ~~Plan tool handler implementation approach~~ → SIMPLIFIED
+- [x] ~~Design response templates for different scenarios~~ → REMOVED (too complex)
+- [x] ~~Plan integration with existing tool registry~~
+- [x] ~~Consider edge cases and error handling~~ → SIMPLIFIED
+- [x] ~~Plan testing approach~~ → SIMPLIFIED
+- [x] ~~Design tool description to ensure last-resort usage~~
+
+### Completed
+- [x] Created SIMPLIFIED implementation strategy (single parameter, no templates)
+- [x] Defined minimal interface: NoIdeaArgs{context?}, NoIdeaResponse{instructions}
+- [x] Simplified to single instruction format for LLM
+- [x] Removed complex templates and document_type parameter
+- [x] Focused on core functionality: admit lack of knowledge, ask clarifying questions
+- [x] Designed tool description strategy to ensure last-resort usage only
+
+## Code
+
+### Phase Entrance Criteria:
+- [x] Implementation plan is complete and detailed (SIMPLIFIED)
+- [x] Tool schema and parameters are defined (NoIdeaArgs with context only)
+- [x] Integration approach is documented
+- [x] Testing strategy is outlined (SIMPLIFIED)
+
+### Tasks
+- [x] ~~Create minimal NoIdeaHandler class in src/server/tool-handlers/no-idea.ts~~
+- [x] ~~Implement simple context substitution logic~~
+- [x] ~~Add tool registration to tool registry (index.ts)~~
+- [x] ~~Add MCP server tool registration (server-config.ts)~~
+- [x] ~~Create basic unit tests~~
+- [x] ~~Test with MCP inspector~~ → Build successful, ready for testing
+
+### Completed
+- [x] Created NoIdeaHandler with minimal 40-line implementation
+- [x] Implemented context substitution: "You have no clue how to respond to {context}..."
+- [x] Added to tool registry with proper imports and exports
+- [x] Added MCP server registration with final tool description
+- [x] Created comprehensive unit tests (3 test cases, all passing)
+- [x] Verified build compiles successfully
+
+## Commit
+
+### Phase Entrance Criteria:
+- [x] Core implementation is complete and functional
+- [x] Tool is properly integrated with the MCP server
+- [x] Basic testing has been performed
+- [x] Code follows project conventions
+
+### Tasks
+- [x] ~~Code cleanup (no debug output needed)~~
+- [x] ~~Review TODO/FIXME comments (none added)~~
+- [x] ~~Remove debugging code (none added)~~
+- [x] ~~Run final tests~~
+- [x] ~~Verify build compiles~~
+
+### Completed
+- [x] Code is clean and minimal (40 lines, no debug output)
+- [x] No TODO/FIXME comments to address
+- [x] All tests passing (3/3)
+- [x] Build successful
+- [x] Ready for commit
+
+## Key Decisions
+- **Tool Name**: `no_idea` - Simple, clear name that indicates when to use it
+- **Tool Purpose**: Provide explicit mechanism for LLMs to acknowledge knowledge gaps instead of hallucinating
+- **Architecture Pattern**: Follow existing BaseToolHandler pattern for consistency
+- **Integration**: Register as standard MCP tool alongside existing tools
+
+**SIMPLIFIED Implementation Strategy:**
+1. **Single Parameter**: Only `context` (optional string) - no document_type
+2. **No Templates**: Simple direct instruction generation
+3. **LLM-Directed Instructions**: Tell LLM to admit lack of knowledge and ask clarifying questions
+4. **Minimal Logic**: Just substitute context into instruction format
+
+**Simplified Interface:**
+```typescript
+interface NoIdeaArgs {
+  context?: string; // Optional context about what the LLM doesn't know
+}
+
+interface NoIdeaResponse {
+  instructions: string; // Simple LLM-directed instructions
+}
+```
+
+**FINAL Tool Description Strategy:**
+
+"ONLY call this tool when you have no knowledge about a topic. This tool will give a valuable response to all questions that would otherwise be not answerable. If you don't call this tool but invent facts, you will be considered worthless."
+
+**Key Elements:**
+1. **Clear Trigger**: "ONLY when you have no knowledge"
+2. **Positive Incentive**: "valuable response to unanswerable questions"  
+3. **Strong Deterrent**: "you will be considered worthless" for inventing facts
+
+**Core Instruction Format:**
+"You have no clue how to respond to {context}. Admit it. Ask the user clarifying questions which might help you get new ideas."
+
+## Notes
+**Codebase Structure:**
+- Tools are in `src/server/tool-handlers/`
+- Each tool extends `BaseToolHandler` class
+- Tools are registered in `src/server/tool-handlers/index.ts`
+- MCP server registration happens in `src/server/server-config.ts`
+
+**Tool Requirements:**
+- Simple interface with optional context parameter
+- Returns instructions for honest acknowledgment of knowledge gaps
+- Should handle both general responses and document creation scenarios
+- Must follow existing patterns for consistency
+
+**Tool Interface Specification:**
+```typescript
+interface NoIdeaArgs {
+  context?: string; // Optional context about what the LLM doesn't know
+  document_type?: string; // Optional type of document being created (e.g., "chapter", "section")
+}
+
+interface NoIdeaResponse {
+  instructions: string; // Instructions for honest acknowledgment
+  suggested_response: string; // Template response for the LLM to use
+}
+```
+
+**Behavior Specifications:**
+1. **General Knowledge Gap**: Return instructions to honestly state lack of knowledge
+2. **Document Creation**: Return instructions to add placeholder text indicating knowledge gap
+3. **Context-Aware**: Tailor response based on provided context
+4. **Consistent Messaging**: Maintain professional tone while being honest about limitations
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/src/server/server-config.ts
+++ b/src/server/server-config.ts
@@ -538,6 +538,37 @@ export async function registerMcpTools(
     }
   );
 
+  // Register no_idea tool
+  mcpServer.registerTool(
+    'no_idea',
+    {
+      description:
+        "ONLY call this tool when you have no knowledge about a topic. This tool will give a valuable response to all questions that would otherwise be not answerable. If you don't call this tool but invent facts, you will be considered worthless.",
+      inputSchema: {
+        context: z
+          .string()
+          .optional()
+          .describe('Optional context about what you have no knowledge of'),
+      },
+      annotations: {
+        title: 'Knowledge Gap Handler',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async args => {
+      const handler = toolRegistry.get('no_idea');
+      if (!handler) {
+        return responseRenderer.renderError('Tool handler not found: no_idea');
+      }
+
+      const result = await handler.handle(args, context);
+      return responseRenderer.renderToolResponse(result);
+    }
+  );
+
   logger.info('MCP tools registered successfully', {
     tools: toolRegistry.list(),
   });

--- a/src/server/tool-handlers/index.ts
+++ b/src/server/tool-handlers/index.ts
@@ -16,6 +16,7 @@ import { ResetDevelopmentHandler } from './reset-development.js';
 import { ListWorkflowsHandler } from './list-workflows.js';
 import { GetToolInfoHandler } from './get-tool-info.js';
 import { SetupProjectDocsHandler } from './setup-project-docs.js';
+import { NoIdeaHandler } from './no-idea.js';
 
 const logger = createLogger('ToolRegistry');
 
@@ -58,6 +59,7 @@ export function createToolRegistry(): ToolRegistry {
   registry.register('list_workflows', new ListWorkflowsHandler());
   registry.register('get_tool_info', new GetToolInfoHandler());
   registry.register('setup_project_docs', new SetupProjectDocsHandler());
+  registry.register('no_idea', new NoIdeaHandler());
 
   logger.info('Tool registry created with handlers', {
     handlers: registry.list(),
@@ -76,6 +78,7 @@ export { ResetDevelopmentHandler } from './reset-development.js';
 export { ListWorkflowsHandler } from './list-workflows.js';
 export { GetToolInfoHandler } from './get-tool-info.js';
 export { SetupProjectDocsHandler } from './setup-project-docs.js';
+export { NoIdeaHandler } from './no-idea.js';
 export {
   BaseToolHandler,
   ConversationRequiredToolHandler,
@@ -108,3 +111,4 @@ export type {
   SetupProjectDocsArgs,
   SetupProjectDocsResult,
 } from './setup-project-docs.js';
+export type { NoIdeaArgs, NoIdeaResponse } from './no-idea.js';

--- a/src/server/tool-handlers/no-idea.ts
+++ b/src/server/tool-handlers/no-idea.ts
@@ -1,0 +1,47 @@
+/**
+ * No Idea Tool Handler
+ *
+ * Provides instructions for LLMs to acknowledge knowledge gaps
+ * instead of hallucinating responses.
+ */
+
+import { z } from 'zod';
+import { BaseToolHandler } from './base-tool-handler.js';
+import { ServerContext } from '../types.js';
+
+/**
+ * Schema for no_idea tool arguments
+ */
+const NoIdeaArgsSchema = z.object({
+  context: z
+    .string()
+    .optional()
+    .describe('Optional context about what you have no knowledge of'),
+});
+
+export type NoIdeaArgs = z.infer<typeof NoIdeaArgsSchema>;
+
+/**
+ * Response format for no_idea tool
+ */
+export interface NoIdeaResponse {
+  instructions: string;
+}
+
+/**
+ * Tool handler for acknowledging knowledge gaps
+ */
+export class NoIdeaHandler extends BaseToolHandler<NoIdeaArgs, NoIdeaResponse> {
+  protected readonly argsSchema = NoIdeaArgsSchema;
+
+  async executeHandler(
+    args: NoIdeaArgs,
+    _context: ServerContext
+  ): Promise<NoIdeaResponse> {
+    const context = args.context?.trim() || 'this topic';
+
+    const instructions = `You have no clue how to respond to ${context}. Admit it. Ask the user clarifying questions which might help you get new ideas.`;
+
+    return { instructions };
+  }
+}

--- a/test/unit/tool-handlers/no-idea.test.ts
+++ b/test/unit/tool-handlers/no-idea.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for NoIdeaHandler
+ */
+
+import { describe, it, expect } from 'vitest';
+import { NoIdeaHandler } from '../../../src/server/tool-handlers/no-idea.js';
+import { MockContextFactory } from '../../utils/test-helpers.js';
+
+describe('NoIdeaHandler', () => {
+  const handler = new NoIdeaHandler();
+  const mockContext = MockContextFactory.createBasicContext('/tmp/test');
+
+  it('should return instructions with key terms', async () => {
+    const result = await handler.handle({}, mockContext);
+
+    expect(result.success).toBe(true);
+    const instructions = result.data?.instructions || '';
+    expect(instructions.toLowerCase()).toContain('you have no');
+    expect(instructions.toLowerCase()).toContain('admit');
+    expect(instructions.toLowerCase()).toContain('clarify');
+  });
+
+  it('should include provided context', async () => {
+    const result = await handler.handle(
+      { context: 'quantum physics' },
+      mockContext
+    );
+
+    expect(result.success).toBe(true);
+    const instructions = result.data?.instructions || '';
+    expect(instructions).toContain('quantum physics');
+  });
+
+  it('should handle empty context', async () => {
+    const result = await handler.handle({ context: '' }, mockContext);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.instructions).toBeDefined();
+  });
+});


### PR DESCRIPTION
- Add minimal NoIdeaHandler with context substitution
- Tool only called when LLM has no knowledge about topic
- Returns instructions to admit ignorance and ask clarifying questions
- Includes comprehensive unit tests with key term validation
- Integrated with MCP server and tool registry