### PR TITLE
fix: complete Windows path duplication fix in remaining files

### DIFF
--- a/src/server/resource-handlers/workflow-resource.ts
+++ b/src/server/resource-handlers/workflow-resource.ts
@@ -7,6 +7,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createLogger } from '../../logger.js';
 import {
   ResourceHandler,
@@ -71,7 +72,7 @@ export class WorkflowResourceHandler implements ResourceHandler {
         // Handle predefined workflows
         // Get the workflows directory path - more reliable approach
         const currentFileUrl = import.meta.url;
-        const currentFilePath = new URL(currentFileUrl).pathname;
+        const currentFilePath = fileURLToPath(currentFileUrl);
 
         // Navigate from the compiled location to the project root
         // From dist/server/resource-handlers/workflow-resource.js -> project root

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -7,6 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import { createLogger } from './logger.js';
 import { DEFAULT_WORKFLOW_NAME } from './constants.js';
 import { StateMachineLoader } from './state-machine-loader.js';
@@ -188,7 +189,7 @@ export class WorkflowManager {
    */
   private findWorkflowsDirectory(): string | null {
     const currentFileUrl = import.meta.url;
-    const currentFilePath = new URL(currentFileUrl).pathname;
+    const currentFilePath = fileURLToPath(currentFileUrl);
     const strategies: string[] = [];
 
     // Strategy 1: Relative to current file (development and direct npm scenarios)


### PR DESCRIPTION
Extends the Windows path duplication fix from commit b0b0ee9 to cover all remaining instances of new URL().pathname pattern. Replaces with fileURLToPath() for proper cross-platform file:// URL to path conversion.

Fixed files:
- src/workflow-manager.ts: findWorkflowsDirectory method
- src/server/resource-handlers/workflow-resource.ts: workflow path resolution

This resolves the remaining C:\C:\Users\... path duplication errors when running CLI commands on Windows systems.

🤖 Generated with [Claude Code](https://claude.ai/code)