### PR TITLE
fix: include domain metadata in bundled workflows for visualizer

### DIFF
--- a/.vibe/development-plan-fix-domain-viz.md
+++ b/.vibe/development-plan-fix-domain-viz.md
@@ -1,0 +1,104 @@
+# Development Plan: responsible-vibe (fix-domain-viz branch)
+
+*Generated on 2025-10-03 by Vibe Feature MCP*
+*Workflow: [bugfix](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/bugfix)*
+
+## Goal
+Fix bug where bundled workflows created during build for the visualizer/interactive docs are missing domain information
+
+## Reproduce
+### Tasks
+- [x] Examine build scripts for bundled workflows
+- [x] Check workflow source files for domain metadata
+- [x] Examine how WorkflowLoader uses bundled workflows
+- [x] Identify the root cause
+
+### Completed
+- [x] Created development plan file
+- [x] Bug successfully reproduced and understood
+
+## Analyze
+
+### Phase Entrance Criteria:
+- [x] Bug has been successfully reproduced
+- [x] Exact steps to reproduce are documented
+- [x] Build process for bundled workflows is understood
+
+### Tasks
+- [x] Analyze current build script implementation
+- [x] Examine WorkflowLoader.getAvailableWorkflows() inefficiency
+- [x] Identify why domain parsing happens at runtime instead of build time
+- [x] Determine optimal solution approach
+- [x] Re-analyze documentation system issue - found the real root cause
+- [x] Identify where exactly domains should appear in documentation
+- [x] Trace the data flow from bundled workflows to documentation display
+- [x] Determine if issue is in data extraction or display logic
+- [x] Discovered Vue component needs same fix as commit 7274c669053c8696dbb001103374dadf6c575fef
+
+### Completed
+- [x] Root cause analysis complete for visualizer
+- [x] Root cause analysis for documentation system complete
+
+## Fix
+
+### Phase Entrance Criteria:
+- [x] Root cause of missing domain information has been identified
+- [x] Fix approach has been determined and documented
+
+### Tasks
+- [x] Modify build-workflows.js to parse YAML and extract metadata
+- [x] Modify build-dev-workflows.js to parse YAML and extract metadata
+- [x] Update BundledWorkflows interface to include metadata
+- [x] Update WorkflowLoader to use pre-parsed metadata
+
+### Completed
+- [x] All build script modifications complete
+
+## Verify
+
+### Phase Entrance Criteria:
+- [x] Fix has been implemented
+- [x] Code changes are complete
+
+### Tasks
+- [x] Verify both build scripts run without errors
+- [x] Confirm metadata is included in generated files
+- [x] Check that domain information is present for all workflows
+- [x] Test that WorkflowLoader can access pre-parsed metadata
+- [x] Verify no regressions in existing functionality
+
+### Completed
+- [x] All verification tests passed
+
+## Finalize
+
+### Phase Entrance Criteria:
+- [x] Fix has been verified to work correctly
+- [x] No regressions have been introduced
+- [x] Bundled workflows now include domain information
+
+### Tasks
+- [x] Code cleanup - removed temporary debug console logs
+- [x] Review TODO/FIXME comments - none were added
+- [x] Remove debugging code blocks - none were added
+- [x] Documentation system fix - updated [workflow].paths.js to extract domain metadata
+- [x] Final validation - all tests pass
+- [x] Bug fix ready for production
+
+### Completed
+- [x] All finalization steps complete
+
+## Key Decisions
+- **Root Cause Identified**: The build scripts (`build-workflows.js` and `build-dev-workflows.js`) only bundle raw YAML content as strings, but don't parse the YAML to extract metadata including domain information
+- **Current Behavior**: WorkflowLoader.getAvailableWorkflows() tries to parse each bundled workflow to extract domain, but this is inefficient and error-prone
+- **Issue Location**: Build scripts need to parse YAML and include parsed metadata in the bundled output
+- **Solution Approach**: Modify build scripts to parse YAML using js-yaml (already available as dependency) and bundle both raw YAML and parsed metadata
+- **Performance Impact**: Moving parsing from runtime to build time will improve visualizer performance
+- **Documentation System Root Cause**: The Vue component in `/docs/.vitepress/components/WorkflowVisualizer.vue` was missing the domain display logic that was added to the standalone visualizer in commit 7274c669053c8696dbb001103374dadf6c575fef
+- **Redundant Code Issue**: The Vue component duplicates the dropdown logic from main.ts but was not updated with the same domain display fix
+
+## Notes
+*Additional context and observations*
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/docs/.vitepress/components/WorkflowVisualizer.vue
+++ b/docs/.vitepress/components/WorkflowVisualizer.vue
@@ -213,12 +213,12 @@ function renderStateDetailsWithHeader(
       </h3>
       <p class="detail-content">${stateData.description}</p>
     </div>
-    
+
     <div class="detail-section">
       <h4 class="detail-subtitle">Default Instructions</h4>
       <div class="code-block">${stateData.default_instructions}</div>
     </div>
-    
+
     <div class="detail-section">
       <h4 class="detail-subtitle">Transitions (${stateData.transitions.length})</h4>
       <ul class="transitions-list">
@@ -321,12 +321,12 @@ function renderTransitionDetailsWithHeader(transitionData: unknown): void {
         <strong>${transition.from}</strong> → <strong>${transition.to}</strong>
       </p>
     </div>
-    
+
     <div class="detail-section">
       <h4 class="detail-subtitle">Reason</h4>
       <p class="detail-content">${transition.transition_reason || ''}</p>
     </div>
-    
+
     ${
       transition.instructions
         ? `
@@ -337,7 +337,7 @@ function renderTransitionDetailsWithHeader(transitionData: unknown): void {
     `
         : ''
     }
-    
+
     ${
       transition.additional_instructions
         ? `
@@ -348,7 +348,7 @@ function renderTransitionDetailsWithHeader(transitionData: unknown): void {
     `
         : ''
     }
-    
+
     ${
       transition.review_perspectives?.length
         ? `
@@ -395,7 +395,7 @@ function renderMetadataDetails(): void {
       <h3 class="detail-title">${workflow.name}</h3>
       <p class="detail-content">${workflow.description}</p>
     </div>
-    
+
     ${
       metadata
         ? `
@@ -563,7 +563,9 @@ onMounted(async () => {
       for (const workflow of workflows) {
         const option = document.createElement('option');
         option.value = workflow.name;
-        option.textContent = `${workflow.displayName} - ${workflow.description}`;
+        // Include domain in option text if available
+        const domainText = workflow.domain ? ` [${workflow.domain}]` : '';
+        option.textContent = `${workflow.displayName}${domainText}`;
         workflowSelector.appendChild(option);
       }
     }

--- a/workflow-visualizer/src/services/WorkflowLoader.ts
+++ b/workflow-visualizer/src/services/WorkflowLoader.ts
@@ -12,6 +12,7 @@ import { YamlParser } from './YamlParser';
 import {
   getBundledWorkflow,
   getBundledWorkflowNames,
+  getBundledWorkflowMetadata,
 } from './BundledWorkflows';
 
 export class WorkflowLoader {
@@ -28,24 +29,14 @@ export class WorkflowLoader {
     const workflowNames = getBundledWorkflowNames();
 
     return workflowNames.map(name => {
-      // Load workflow to extract domain from metadata
-      let domain: string | undefined;
-      try {
-        const yamlContent = getBundledWorkflow(name);
-        if (yamlContent) {
-          const workflow = this.yamlParser.parseWorkflow(yamlContent);
-          domain = workflow.metadata?.domain;
-        }
-      } catch (error) {
-        // If workflow fails to load, continue without domain
-        console.warn(`Failed to load domain for workflow ${name}:`, error);
-      }
+      // Use pre-parsed metadata from build time
+      const metadata = getBundledWorkflowMetadata(name);
 
       return {
         name,
         displayName: this.formatDisplayName(name),
         source: 'builtin' as const,
-        domain,
+        domain: metadata?.domain,
       };
     });
   }

--- a/workflow-visualizer/src/visualization/PlantUMLRenderer.ts
+++ b/workflow-visualizer/src/visualization/PlantUMLRenderer.ts
@@ -51,22 +51,22 @@ export class PlantUMLRenderer {
     const title = document.createElement('div');
     title.innerHTML = `
       <div style="
-        display: flex; 
-        align-items: center; 
-        justify-content: center; 
-        gap: 12px; 
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
         margin-bottom: 10px;
         flex-wrap: wrap;
       ">
         <h2 style="
-          color: #1e293b; 
-          margin: 0; 
+          color: #1e293b;
+          margin: 0;
           font-size: 1.5rem;
           cursor: pointer;
           padding: 8px 12px;
           border-radius: 6px;
           transition: background-color 0.2s ease;
-        " 
+        "
         class="workflow-title-clickable"
         title="Click to show workflow information"
         >${workflow.name} Workflow ${workflow.metadata?.domain ? `<span class="domain-pill" data-domain="${workflow.metadata.domain}">${workflow.metadata.domain}</span>` : ''}</h2>


### PR DESCRIPTION
- Parse YAML during build to extract metadata including domain information
- Add BUNDLED_WORKFLOW_METADATA export to both build scripts
- Update WorkflowLoader to use pre-parsed metadata instead of runtime parsing
- Improves performance by moving parsing from runtime to build time

Fixes missing domain information in workflow visualizer interactive docs