### PR TITLE
Make 'no active workflow' message more explicit and directive

### DIFF
--- a/packages/opencode-plugin/src/plugin.ts
+++ b/packages/opencode-plugin/src/plugin.ts
@@ -377,7 +377,7 @@ export const WorkflowsPlugin: Plugin = async (
               messageID: hookInput.messageID || output.message.id,
               type: 'text' as const,
               synthetic: true,
-              text: `No Active Workflow Use the \`start_development\` tool to begin.`,
+              text: `No Active Workflow Detected. You MUST initiate a new development workflow before proceeding. Call the \`start_development\` tool to begin. Do NOT attempt any file edits or tool executions until a workflow is active.`,
             } as (typeof output.parts)[0]);
             return;
           }
@@ -396,7 +396,7 @@ export const WorkflowsPlugin: Plugin = async (
               messageID: hookInput.messageID || output.message.id,
               type: 'text' as const,
               synthetic: true,
-              text: `No Active Workflow Use the \`start_development\` tool to begin.`,
+              text: `No Active Workflow Detected. You MUST initiate a new development workflow before proceeding. Call the \`start_development\` tool to begin. Do NOT attempt any file edits or tool executions until a workflow is active.`,
             } as (typeof output.parts)[0]);
             return;
           }


### PR DESCRIPTION
## Summary
- Make 'no active workflow' message more explicit and directive
- Instructs the AI to call `start_development` tool
- Explicitly prohibits file edits until a workflow is active