### PR TITLE
fix(opencode-plugin): bundle effect into dist instead of peer dependency

### DIFF
--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -24,25 +24,21 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "effect": ">=3.0.0",
     "zod": "^4.1.8"
   },
   "devDependencies": {
     "@codemcp/workflows-core": "workspace:*",
     "@codemcp/workflows-server": "workspace:*",
-    "effect": "3.21.1",
     "rimraf": "^6.0.1",
     "tsup": "^8.0.0",
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "*",
-    "effect": ">=3.0.0"
+    "@anthropic-ai/sdk": "*"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {
-      "optional": true
-    },
-    "effect": {
       "optional": true
     }
   },

--- a/packages/opencode-plugin/tsup.config.ts
+++ b/packages/opencode-plugin/tsup.config.ts
@@ -14,8 +14,12 @@ export default defineConfig({
   bundle: true,
   // Zod is external (it's a true peer dependency)
   external: ['zod'],
-  // Bundle core and server packages (they're private, not published)
-  noExternal: ['@codemcp/workflows-core', '@codemcp/workflows-server'],
+  // Bundle core, server, and effect — not guaranteed to be available in standalone plugin installs
+  noExternal: [
+    '@codemcp/workflows-core',
+    '@codemcp/workflows-server',
+    'effect',
+  ],
   target: 'node20',
   sourcemap: false,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: '*'
         version: 0.80.0(zod@4.3.6)
+      effect:
+        specifier: '>=3.0.0'
+        version: 3.21.1
       zod:
         specifier: ^4.1.8
         version: 4.3.6
@@ -190,9 +193,6 @@ importers:
       '@codemcp/workflows-server':
         specifier: workspace:*
         version: link:../mcp-server
-      effect:
-        specifier: 3.21.1
-        version: 3.21.1
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2


### PR DESCRIPTION
The plugin is installed in an isolated cache directory by opencode, so peer dependencies are not resolved. Move effect to a regular dependency and add it to noExternal in tsup so it is bundled into dist/index.js.