### PR TITLE
fix(opencode-plugin): prevent MCP server startup when loaded as plugin

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -95,8 +95,7 @@ export { main as startMcpServer };
 // More robust check that works with npx and direct execution
 const isMainModule =
   import.meta.url === `file://${process.argv[1]}` ||
-  process.argv[1]?.endsWith('ade-workflows-server') ||
-  process.argv[1]?.endsWith('index.js');
+  process.argv[1]?.endsWith('ade-workflows-server');
 
 if (isMainModule) {
   await main().catch(error => {

--- a/packages/opencode-plugin/tsup.config.ts
+++ b/packages/opencode-plugin/tsup.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from 'tsup';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   entry: {
@@ -22,4 +26,20 @@ export default defineConfig({
   ],
   target: 'node20',
   sourcemap: false,
+  esbuildOptions(options) {
+    // Resolve @codemcp/workflows-server from its source entry point so that
+    // esbuild can deduplicate @codemcp/workflows-core across both the server
+    // and the direct imports in this package. Without this, the pre-built
+    // dist/index.js of @codemcp/workflows-server already contains an inlined
+    // copy of @codemcp/workflows-core, and esbuild bundles a second copy for
+    // the direct imports here — resulting in two separate logSinkInstance
+    // globals that prevent the OpenCode log sink from being shared.
+    options.alias = {
+      ...options.alias,
+      '@codemcp/workflows-server': path.resolve(
+        __dirname,
+        '../mcp-server/src/index.ts'
+      ),
+    };
+  },
 });


### PR DESCRIPTION
## Problem

When the opencode plugin (`dist/index.js`) was loaded by opencode (a bun binary), `process.argv[1]` was set to `/$bunfs/root/src/index.js` — the bun bundle's internal entry point. The `isMainModule` guard in `mcp-server/src/index.ts` included `endsWith('index.js')`, which matched this path, causing the full MCP server (`createResponsibleVibeMCPServer`) to start inside the plugin process on every plugin load.

This flooded stderr with dozens of INFO logs from `WorkflowManager`/`StateMachineLoader` before `WorkflowsPlugin` was called and the OpenCode log sink registered, corrupting the TUI.

## Fix

Remove the unreliable `endsWith('index.js')` heuristic from `isMainModule`. The two remaining checks are sufficient:
- `import.meta.url === file://${process.argv[1]}` — covers `node dist/index.js`
- `endsWith('ade-workflows-server')` — covers the npx bin symlink

Also deduplicate `@codemcp/workflows-core` in the opencode plugin bundle via a tsup `esbuildOptions` alias that resolves `@codemcp/workflows-server` from source, preventing two separate `logSinkInstance` globals.