### PR TITLE
fix(cli): bundle js-yaml into CLI dist

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -9,7 +9,16 @@ export default defineConfig({
   clean: true,
   bundle: true,
   external: ['@modelcontextprotocol/sdk'],
-  noExternal: ['@codemcp/workflows-core', '@codemcp/workflows-server'],
+  noExternal: [
+    '@codemcp/workflows-core',
+    '@codemcp/workflows-server',
+    // js-yaml is imported at runtime in the chunk (via the .vibe/config.yaml
+    // YAML parser). It is declared in this package's `dependencies` but NOT
+    // in the published root package.json, so `npx` does not install it and
+    // the wizard fails with `ERR_MODULE_NOT_FOUND: js-yaml`. Bundling it
+    // into the chunk makes the wizard self-contained.
+    'js-yaml',
+  ],
   target: 'node20',
   sourcemap: false,
 });


### PR DESCRIPTION
 to prevent ERR_MODULE_NOT_FOUND on npx

## Intent

When the CLI wizard is run via `npx @codemcp/workflows-cli`, the root package that npx installs does not include js-yaml as a transitive dependency visible at runtime. The wizard reads .vibe/config.yaml using js-yaml at startup, which causes an ERR_MODULE_NOT_FOUND crash.

## Key decisions

- Added 'js-yaml' to the noExternal list in tsup.config.ts so it is inlined into the bundle at build time, making the CLI self-contained regardless of what the npx install resolution picks up
- js-yaml is already declared in the package's dependencies (so it is present during the build); this change only affects the output bundling, not the dependency graph